### PR TITLE
Fix/fixing the filter

### DIFF
--- a/src/jsMain/kotlin/sugarmelt/app/SugarMelt.kt
+++ b/src/jsMain/kotlin/sugarmelt/app/SugarMelt.kt
@@ -706,15 +706,20 @@ class SugarMelt(private val root: HTMLElement) {
     }
 
     private fun filterSome(pattern: String) {
-        walkData {
-            val matchingPattern = pattern.isBlank() || isMatchingPattern(pattern, it)
-            it.ui.childrenPoint.apply {
-                if (matchingPattern) {
-                    classList -= "hidden"
-                    walkUp { generalData -> generalData.ui.childrenPoint.classList -= "hidden" }
-                } else {
-                    classList += "hidden"
-                }
+        walkData { data ->
+            val matches = pattern.isBlank() || isMatchingPattern(pattern, data)
+
+            // Apply the hidden class to both the name and the value cells
+            data.ui.labelPoint.apply {
+                if (matches) classList -= "hidden" else classList += "hidden"
+            }
+            data.ui.childrenPoint.apply {
+                if (matches) classList -= "hidden" else classList += "hidden"
+            }
+
+            // Ensure that ancestor tables stay visible when something matches
+            if (matches) {
+                walkUp(data) { ancestor -> ancestor.ui.childrenPoint.classList -= "hidden" }
             }
         }
     }

--- a/src/jsMain/resources/devtools.html
+++ b/src/jsMain/resources/devtools.html
@@ -6,7 +6,12 @@
           name="viewport"/>
     <meta content="ie=edge" http-equiv="X-UA-Compatible"/>
     <title>SugarMelt</title>
-    <!--suppress HtmlUnknownTarget -->
+    <script src="kotlin-kotlin-stdlib.js"></script>
+    <script src="kotlinx-atomicfu.js"></script>
+    <script src="kotlin_org_jetbrains_kotlin_kotlin_dom_api_compat.js"></script>
+    <script src="Kotlin-Immutable-Collections-kotlinx-collections-immutable.js"></script>
+    <script src="kotlin-css-generator-js-ir.js"></script>
+    <script src="i18n4k-i18n4k-core.js"></script>
     <script src="SugarMelt.js"></script>
 </head>
 <body></body>


### PR DESCRIPTION
## Problem

When using the filter, non-matching variable names were still displayed in the UI, causing excessive scrolling and making it difficult to find relevant variables.

## Solution

### Code Changes

1. **SugarMelt.kt** — Updated `filterSome()` function
   - Now hides both the variable **name** (`labelPoint`) and **children** (`childrenPoint`) for non-matching items
   - Previously only hid the children, leaving variable names visible
   - Maintains ancestor visibility when a match is found

2. **devtools.html** — Fixed script dependency loading order
   - Added all required Kotlin/JS library dependencies in correct load order
   - Ensures the extension loads properly after building

### Result

The filter now displays **only matching variables and their names**, eliminating unnecessary scrolling and clutter while maintaining the full ancestor chain for context.

## Testing

✅ **Firefox Developer Edition** — Tested and working on SugarCube games  
✅ **Brave (Chromium-based)** — Tested and working on SugarCube games
